### PR TITLE
Fix  the error due to empty wic out file

### DIFF
--- a/scripts/libs/package_wic.py
+++ b/scripts/libs/package_wic.py
@@ -210,7 +210,7 @@ def PackageWic(args, proot):
                                  proot, shell=True, logfile=args.logfile)
     # Get the exact output file from wic tmp dir
     WicOutFile = [f for f in glob.glob(
-        os.path.join(WicTmpBuildDir, 'rootfs-*.direct*'))
+        os.path.join(WicTmpBuildDir, '*.direct*'))
         if not re.search('.+.direct.p.+', f)][0]
     # Get the output file extention
     WicOutExt = os.path.basename(


### PR DESCRIPTION
$ petalinux-package wic ...
[ERROR] list index out of range
After successful wic create, it generates 
petalinux-image-minimal-202411160236-mmcblk0.direct.p1 
petalinux-image-minimal-202411160236-mmcblk0.direct.p2 
petalinux-image-minimal-202411160236-mmcblk0.direct.xz
under wic-tmp
But os.path.join(WicTmpBuildDir, 'rootfs-*.direct*') is used for searcing wic images. It results in the empty list of WicOutFile. WicOutFile[0] causes the above error.
To fix it, 'rootfs-' is removed from the search pattern.