### PR TITLE
Fix project argument of petalinux-package bsp

### DIFF
--- a/scripts/petalinux-package
+++ b/scripts/petalinux-package
@@ -123,6 +123,12 @@ def main():
             proot = plnx_utils.exit_not_plnx_project(args.project)
         else:
             proot = plnx_utils.exit_not_plnx_project(proot='')
+    else:
+        # Exit if PROOT is not PetaLinux project
+        if args.project:
+            proot = plnx_utils.exit_not_plnx_project(args.project[0])
+        else:
+            proot = plnx_utils.exit_not_plnx_project(proot='')
 
     args.builddir = plnx_vars.BuildDir.format(proot)
     plnx_utils.CreateDir(args.builddir)


### PR DESCRIPTION
$ petalinux-package bsp -o ultra96_base.bsp -p ultra96_base
 [ERROR] Unable to create directory at /build

When using petalinux-package bsp, the project(-p) argument is not used. Empty project root(proot='') causes the above error. 
The project argument for bsp is not a string but a list of a string.  
This fix takes the first element of the list as the project root(proot)